### PR TITLE
1.0.2: AmbientContexts 1.1.1, and EF6+ compatibility fixes.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,257 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Rule Severities ####
+dotnet_diagnostic.CA1822.severity = none # CA1822: Instance member does not access instance data and can be marked as static
+dotnet_diagnostic.CS1573.severity = none # CS1573: Undocumented public symbol while -doc compiler option is used
+dotnet_diagnostic.CS1591.severity = none # CS1591: Missing XML comment for publicly visible type
+dotnet_diagnostic.CA1816.severity = none # CA1816: Dispose() should call GC.SuppressFinalize()
+
+#### Core EditorConfig Options ####
+
+# Default charset
+charset = utf-8
+
+# Indentation and spacing
+indent_size = 4
+indent_style = tab
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = true
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true:suggestion
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_property = true:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = false:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:silent
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true:silent
+dotnet_style_operator_placement_when_wrapping = end_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = false
+dotnet_style_prefer_inferred_tuple_names = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = true
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = false
+csharp_prefer_simple_using_statement = true
+csharp_style_namespace_declarations = file_scoped
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = false
+csharp_style_implicit_object_creation_when_type_is_apparent = false
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:suggestion
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.static_field_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_field_should_be_pascal_case.symbols = static_field
+dotnet_naming_rule.static_field_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_or_internal_field_should_be__camelcase.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be__camelcase.style = _camelcase
+
+dotnet_naming_rule.method_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.method_should_be_pascal_case.symbols = method
+dotnet_naming_rule.method_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.method.applicable_kinds = method
+dotnet_naming_symbols.method.applicable_accessibilities = public
+dotnet_naming_symbols.method.required_modifiers = 
+
+dotnet_naming_symbols.static_field.applicable_kinds = field
+dotnet_naming_symbols.static_field.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.static_field.required_modifiers = static
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix = 
+dotnet_naming_style._camelcase.word_separator = 
+dotnet_naming_style._camelcase.capitalization = camel_case

--- a/Identities.Azure/AzureBlobApplicationInstanceIdRenter.cs
+++ b/Identities.Azure/AzureBlobApplicationInstanceIdRenter.cs
@@ -100,7 +100,7 @@ namespace Architect.Identities
 			{
 				var creationResponse = this.Client.CreateIfNotExists(Azure.Storage.Blobs.Models.PublicAccessType.None);
 				var creationResponsStatusCode = creationResponse?.GetRawResponse().Status;
-				if (creationResponsStatusCode != null && creationResponsStatusCode != (int)HttpStatusCode.OK && creationResponsStatusCode != (int)HttpStatusCode.Created)
+				if (creationResponsStatusCode is not null && creationResponsStatusCode != (int)HttpStatusCode.OK && creationResponsStatusCode != (int)HttpStatusCode.Created)
 					throw new Exception($"{this.GetType().Name} received an unexpected status code trying to ensure that the container exists: {creationResponsStatusCode}.");
 			}
 

--- a/Identities.Azure/Identities.Azure.csproj
+++ b/Identities.Azure/Identities.Azure.csproj
@@ -13,12 +13,6 @@
 		<VersionPrefix>1.0.2</VersionPrefix>
 		<PackageReleaseNotes></PackageReleaseNotes>
 		<Description>
-Azure-based implementations for the Architect.Identities package.
-
-This package allows Azure blob storage to be used as the synchronization mechanism for assigning unique IDs to each application instance.
-
-services.AddIdGenerator(generator =&gt; generator.UseAzureBlobStorageContainer(new BlobContainerClient("ConnectionString", "ContainerName")));
-
 Release notes:
 
 1.0.2:
@@ -26,6 +20,14 @@ Release notes:
 
 1.0.1:
 - Now using AmbientContexts 1.1.0, for a performance improvement.
+
+Description:
+
+Azure-based implementations for the Architect.Identities package.
+
+This package allows Azure blob storage to be used as the synchronization mechanism for assigning unique IDs to each application instance.
+
+services.AddIdGenerator(generator =&gt; generator.UseAzureBlobStorageContainer(new BlobContainerClient("ConnectionString", "ContainerName")));
 		</Description>
 		<Copyright>The Architect</Copyright>
 		<Company>The Architect</Company>

--- a/Identities.Azure/Identities.Azure.csproj
+++ b/Identities.Azure/Identities.Azure.csproj
@@ -4,15 +4,9 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<AssemblyName>Architect.Identities.Azure</AssemblyName>
 		<RootNamespace>Architect.Identities</RootNamespace>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<NoWarn>1573;1591</NoWarn>
-		<LangVersion>latest</LangVersion>
 		<Nullable>Enable</Nullable>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>9</LangVersion>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Identities.Azure/Identities.Azure.csproj
+++ b/Identities.Azure/Identities.Azure.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.Azure</AssemblyName>
-    <RootNamespace>Architect.Identities</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<AssemblyName>Architect.Identities.Azure</AssemblyName>
+		<RootNamespace>Architect.Identities</RootNamespace>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-    <!-- NoWarn: 1591=MissingXmlComments -->
-    <NoWarn>1573;1591</NoWarn>
-    <LangVersion>latest</LangVersion>
-    <Nullable>Enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<NoWarn>1573;1591</NoWarn>
+		<LangVersion>latest</LangVersion>
+		<Nullable>Enable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <Description>
+	<PropertyGroup>
+		<VersionPrefix>1.0.2</VersionPrefix>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<Description>
 Azure-based implementations for the Architect.Identities package.
 
 This package allows Azure blob storage to be used as the synchronization mechanism for assigning unique IDs to each application instance.
@@ -27,32 +27,35 @@ services.AddIdGenerator(generator =&gt; generator.UseAzureBlobStorageContainer(n
 
 Release notes:
 
+1.0.2:
+- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
+
 1.0.1:
-- See Architect.Identities.
-    </Description>
-    <Copyright>The Architect</Copyright>
-    <Company>The Architect</Company>
-    <Authors>TheArchitectDev, Timovzl</Authors>
-    <RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageTags>Azure, blob, storage, container, ID, IDs, identity, identities, Fluid, generator, generation, IdGenerator, UUID, GUID, auto-increment, entity, entities, PublicIdentities, IdGeneratorScope, flexible, locally, unique</PackageTags>
-  </PropertyGroup>
+- Now using AmbientContexts 1.1.0, for a performance improvement.
+		</Description>
+		<Copyright>The Architect</Copyright>
+		<Company>The Architect</Company>
+		<Authors>TheArchitectDev, Timovzl</Authors>
+		<RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
+		<RepositoryType>Git</RepositoryType>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageTags>Azure, blob, storage, container, ID, IDs, identity, identities, Fluid, generator, generation, IdGenerator, UUID, GUID, auto-increment, entity, entities, PublicIdentities, IdGeneratorScope, flexible, locally, unique</PackageTags>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Architect.Identities" Version="[1.0.1-*, 2.0.0)" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Architect.Identities" Version="[1.0.2-*, 2.0.0)" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.EntityFramework.IntegrationTests/ApplicationInstanceIds/DbContextApplicationInstanceIdSourceExtensionsTests.cs
+++ b/Identities.EntityFramework.IntegrationTests/ApplicationInstanceIds/DbContextApplicationInstanceIdSourceExtensionsTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.Common;
+﻿using System.Data.Common;
 using System.Reflection;
-using System.Threading.Tasks;
 using Architect.Identities.ApplicationInstanceIds;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;

--- a/Identities.EntityFramework.IntegrationTests/DecimalIdMappingTests.cs
+++ b/Identities.EntityFramework.IntegrationTests/DecimalIdMappingTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Architect.Identities.EntityFramework.IntegrationTests.TestHelpers;
 using Microsoft.EntityFrameworkCore;
 using Xunit;

--- a/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
+++ b/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
@@ -1,27 +1,43 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.EntityFramework.IntegrationTests</AssemblyName>
-    <RootNamespace>Architect.Identities.EntityFramework.IntegrationTests</RootNamespace>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyName>Architect.Identities.EntityFramework.IntegrationTests</AssemblyName>
+		<RootNamespace>Architect.Identities.EntityFramework.IntegrationTests</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
+		<NoWarn>1573;1591;CA1822</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
+++ b/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
@@ -4,7 +4,8 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyName>Architect.Identities.EntityFramework.IntegrationTests</AssemblyName>
 		<RootNamespace>Architect.Identities.EntityFramework.IntegrationTests</RootNamespace>
-		<IsPackable>false</IsPackable>
+		<ImplicitUsings>Enable</ImplicitUsings>
+		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
+++ b/Identities.EntityFramework.IntegrationTests/Identities.EntityFramework.IntegrationTests.csproj
@@ -7,13 +7,6 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
-		<NoWarn>1573;1591;CA1822</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="3.1.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Identities.EntityFramework.IntegrationTests/TestHelpers/TestDbContext.cs
+++ b/Identities.EntityFramework.IntegrationTests/TestHelpers/TestDbContext.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Reflection.Emit;
 using Microsoft.EntityFrameworkCore;
 

--- a/Identities.EntityFramework/ApplicationInstanceIds/DbContextApplicationInstanceIdSourceExtensions.cs
+++ b/Identities.EntityFramework/ApplicationInstanceIds/DbContextApplicationInstanceIdSourceExtensions.cs
@@ -145,7 +145,7 @@ namespace Architect.Identities
 
 			iDbContextFactoryType = iDbContextFactoryType?.MakeGenericType(typeof(TDbContext));
 
-			var createDbContextMethod = iDbContextFactoryType?.GetMethods().SingleOrDefault(method => method.Name == "CreateDbContext" && method.GetParameters().Count() == 0);
+			var createDbContextMethod = iDbContextFactoryType?.GetMethods().SingleOrDefault(method => method.Name == "CreateDbContext" && method.GetParameters().Length == 0);
 
 			services.AddTransient(CreateTransactionalExecutor); // DbContext may be registered as anything, which we can support by being transient
 
@@ -155,9 +155,9 @@ namespace Architect.Identities
 				Func<IServiceProvider, DbContext> getDbContext;
 				bool shouldDisposeDbContext;
 
-				var dbContextFactory = serviceProvider.GetService(iDbContextFactoryType);
+				var dbContextFactory = iDbContextFactoryType is null ? null : serviceProvider.GetService(iDbContextFactoryType);
 
-				if (dbContextFactory != null && createDbContextMethod != null)
+				if (dbContextFactory is not null && createDbContextMethod is not null)
 				{
 					getDbContext = serviceProvider => (DbContext)(createDbContextMethod.Invoke(dbContextFactory, parameters: Array.Empty<object>())
 						?? throw new Exception($"The factory produced a null {nameof(DbContext)}."));
@@ -194,7 +194,7 @@ namespace Architect.Identities
 							{
 								var secondConnection = secondDbContext.Database.GetDbConnection();
 								if (!ReferenceEquals(connection, secondConnection))
-									throw new Exception($"To use an in-memory SQLite database, configure a fixed connection.");
+									throw new Exception("To use an in-memory SQLite database, configure a fixed connection.");
 							}
 						}
 						isSqlite = false;

--- a/Identities.EntityFramework/ApplicationInstanceIds/DummyDbConnection.cs
+++ b/Identities.EntityFramework/ApplicationInstanceIds/DummyDbConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace
 namespace Architect.Identities.ApplicationInstanceIds
@@ -10,7 +11,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 	/// </summary>
 	public sealed class DummyDbConnection : DbConnection
 	{
-		public override string ConnectionString { get; set; } = null!;
+		public override string ConnectionString { get; [param: AllowNull] set; } = null!;
 		public override string Database { get; } = null!;
 		public override string DataSource { get; } = null!;
 		public override string ServerVersion { get; } = null!;

--- a/Identities.EntityFramework/DecimalIdMappingExtensions.cs
+++ b/Identities.EntityFramework/DecimalIdMappingExtensions.cs
@@ -82,7 +82,7 @@ namespace Architect.Identities.EntityFramework
 		/// Doing so avoids truncation of decimals to 8 bytes, and ensures that they are reconstituted with their original precision.
 		/// </para>
 		/// <para>
-		/// To do this without repetition for each decimal ID property, call <see cref="StoreDecimalIdsWithCorrectPrecision(ModelBuilder, DbContext, string)"/> on the <see cref="ModelBuilder"/>.
+		/// To do this without repetition for each decimal ID property, call <see cref="StoreDecimalIdsWithCorrectPrecision(ModelBuilder, DbContext, String)"/> on the <see cref="ModelBuilder"/>.
 		/// </para>
 		/// </summary>
 		/// <param name="propertyBuilder">The property builder whose configuration to update.</param>
@@ -103,7 +103,7 @@ namespace Architect.Identities.EntityFramework
 		/// Doing so avoids truncation of decimals to 8 bytes, and ensures that they are reconstituted with their original precision.
 		/// </para>
 		/// <para>
-		/// To do this without repetition for each decimal ID property, call <see cref="StoreDecimalIdsWithCorrectPrecision(ModelBuilder, DbContext, string)"/> on the <see cref="ModelBuilder"/>.
+		/// To do this without repetition for each decimal ID property, call <see cref="StoreDecimalIdsWithCorrectPrecision(ModelBuilder, DbContext, String)"/> on the <see cref="ModelBuilder"/>.
 		/// </para>
 		/// </summary>
 		/// <param name="propertyBuilder">The property builder whose configuration to update.</param>

--- a/Identities.EntityFramework/DecimalIdMappingExtensions.cs
+++ b/Identities.EntityFramework/DecimalIdMappingExtensions.cs
@@ -143,7 +143,7 @@ namespace Architect.Identities.EntityFramework
 			static PropertyInfo? GetPropertyInfo(object property)
 			{
 				// This workaround is needed because the library otherwise breaks if EF 6+ is used by the host application, due to breaking changes in EF
-				return (PropertyInfo?)property.GetType().GetProperty(nameof(IMutableProperty.PropertyInfo))!.GetValue(property)!;
+				return (PropertyInfo?)property.GetType().GetProperty(nameof(IMutableProperty.PropertyInfo))!.GetValue(property);
 			}
 		}
 	}

--- a/Identities.EntityFramework/Identities.EntityFramework.csproj
+++ b/Identities.EntityFramework/Identities.EntityFramework.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.EntityFramework</AssemblyName>
-    <RootNamespace>Architect.Identities.EntityFramework</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<AssemblyName>Architect.Identities.EntityFramework</AssemblyName>
+		<RootNamespace>Architect.Identities.EntityFramework</RootNamespace>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-    <!-- NoWarn: 1591=MissingXmlComments -->
-    <NoWarn>1573;1591</NoWarn>
-    <LangVersion>latest</LangVersion>
-    <Nullable>Enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<NoWarn>1573;1591</NoWarn>
+		<LangVersion>latest</LangVersion>
+		<Nullable>Enable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <Description>
+	<PropertyGroup>
+		<VersionPrefix>1.0.2</VersionPrefix>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<Description>
 EntityFramework extensions for the Architect.Identities package.
 
 Use DbContext-based connections for the Fluid ID generator:
@@ -66,33 +66,37 @@ The extensions in this package special-case SQLite, which requires special treat
 
 Release notes:
 
+1.0.2:
+- Fixed an incompatibility with EF Core 6.0.0+ (caused by a breaking change in EF itself).
+- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
+
 1.0.1:
-- See Architect.Identities.
-    </Description>
-    <Copyright>The Architect</Copyright>
-    <Company>The Architect</Company>
-    <Authors>TheArchitectDev, Timovzl</Authors>
-    <RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageTags>Entity, Framework, EntityFramework, EF, Core, EfCore, ID, IDs, identity, identities, Fluid, distributed, locally, unique, locally-unique, generator, generation, IdGenerator, UUID, GUID, auto-increment, primary, key, entity, entities, PublicIdentities, IdGeneratorScope, flexible</PackageTags>
-  </PropertyGroup>
+- Now using AmbientContexts 1.1.0, for a performance improvement.
+		</Description>
+		<Copyright>The Architect</Copyright>
+		<Company>The Architect</Company>
+		<Authors>TheArchitectDev, Timovzl</Authors>
+		<RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
+		<RepositoryType>Git</RepositoryType>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageTags>Entity, Framework, EntityFramework, EF, Core, EfCore, ID, IDs, identity, identities, Fluid, distributed, locally, unique, locally-unique, generator, generation, IdGenerator, UUID, GUID, auto-increment, primary, key, entity, entities, PublicIdentities, IdGeneratorScope, flexible</PackageTags>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Architect.Identities" Version="[1.0.1-*, 2.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Architect.Identities" Version="[1.0.2-*, 2.0.0)" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.EntityFramework/Identities.EntityFramework.csproj
+++ b/Identities.EntityFramework/Identities.EntityFramework.csproj
@@ -4,15 +4,9 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<AssemblyName>Architect.Identities.EntityFramework</AssemblyName>
 		<RootNamespace>Architect.Identities.EntityFramework</RootNamespace>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<NoWarn>1573;1591</NoWarn>
-		<LangVersion>latest</LangVersion>
 		<Nullable>Enable</Nullable>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>9</LangVersion>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Identities.EntityFramework/Identities.EntityFramework.csproj
+++ b/Identities.EntityFramework/Identities.EntityFramework.csproj
@@ -13,6 +13,17 @@
 		<VersionPrefix>1.0.2</VersionPrefix>
 		<PackageReleaseNotes></PackageReleaseNotes>
 		<Description>
+Release notes:
+
+1.0.2:
+- Fixed an incompatibility with EF Core 6.0.0+ (caused by a breaking change in EF itself).
+- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
+
+1.0.1:
+- Now using AmbientContexts 1.1.0, for a performance improvement.
+
+Description:
+
 EntityFramework extensions for the Architect.Identities package.
 
 Use DbContext-based connections for the Fluid ID generator:
@@ -57,15 +68,6 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 
 The extensions in this package special-case SQLite, which requires special treatment.
-
-Release notes:
-
-1.0.2:
-- Fixed an incompatibility with EF Core 6.0.0+ (caused by a breaking change in EF itself).
-- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
-
-1.0.1:
-- Now using AmbientContexts 1.1.0, for a performance improvement.
 		</Description>
 		<Copyright>The Architect</Copyright>
 		<Company>The Architect</Company>

--- a/Identities.EntityFramework/SqliteDetector.cs
+++ b/Identities.EntityFramework/SqliteDetector.cs
@@ -28,8 +28,8 @@ namespace Architect.Identities.EntityFramework
 				.SingleOrDefault(type => type.Name == "SqliteDatabaseFacadeExtensions" && type.Namespace == "Microsoft.EntityFrameworkCore");
 			var isSqliteMethod = databaseFacadeExtensionsType?.GetMethod("IsSqlite");
 
-			if (isSqliteMethod != null && isSqliteMethod.ReturnType == typeof(bool) &&
-				isSqliteMethod.GetParameters().Count() == 1 && isSqliteMethod.GetParameters().Single().ParameterType == typeof(DatabaseFacade))
+			if (isSqliteMethod is not null && isSqliteMethod.ReturnType == typeof(bool) &&
+				isSqliteMethod.GetParameters().Length == 1 && isSqliteMethod.GetParameters().Single().ParameterType == typeof(DatabaseFacade))
 			{
 				if (database is null) throw new ArgumentNullException(nameof(database));
 

--- a/Identities.Example/Identities.Example.csproj
+++ b/Identities.Example/Identities.Example.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<AssemblyName>Architect.Identities.Example</AssemblyName>
 		<RootNamespace>Architect.Identities.Example</RootNamespace>
-		<IsPackable>false</IsPackable>
+		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Identities.Example/Identities.Example.csproj
+++ b/Identities.Example/Identities.Example.csproj
@@ -8,13 +8,6 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
-		<NoWarn>1573;1591;CA1822</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />

--- a/Identities.Example/Identities.Example.csproj
+++ b/Identities.Example/Identities.Example.csproj
@@ -1,22 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.Example</AssemblyName>
-    <RootNamespace>Architect.Identities.Example</RootNamespace>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<AssemblyName>Architect.Identities.Example</AssemblyName>
+		<RootNamespace>Architect.Identities.Example</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
+		<NoWarn>1573;1591;CA1822</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.IntegrationTests/ApplicationInstanceIds/IdGeneratorWithDifferentRegistrationTests.cs
+++ b/Identities.IntegrationTests/ApplicationInstanceIds/IdGeneratorWithDifferentRegistrationTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.Common;
+﻿using System.Data.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;

--- a/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/SqlServerApplicationInstanceIdRenterExtensionsTests.cs
+++ b/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/SqlServerApplicationInstanceIdRenterExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.Common;
+﻿using System.Data.Common;
 using System.Data.SQLite;
 using System.Reflection;
 using Architect.Identities.ApplicationInstanceIds;

--- a/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/SqliteApplicationInstanceIdRenterExtensionsTests.cs
+++ b/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/SqliteApplicationInstanceIdRenterExtensionsTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SQLite;
-using System.Threading.Tasks;
+﻿using System.Data.SQLite;
 using Architect.Identities.ApplicationInstanceIds;
 using Architect.Identities.IntegrationTests.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;

--- a/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/StandardSqlApplicationInstanceIdRenterTests.cs
+++ b/Identities.IntegrationTests/ApplicationInstanceIds/Implementations/StandardSqlApplicationInstanceIdRenterTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data.Common;
+﻿using System.Data.Common;
 using System.Data.SQLite;
 using Architect.Identities.ApplicationInstanceIds;
 using Architect.Identities.IntegrationTests.TestHelpers;

--- a/Identities.IntegrationTests/Identities.IntegrationTests.csproj
+++ b/Identities.IntegrationTests/Identities.IntegrationTests.csproj
@@ -4,7 +4,8 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyName>Architect.Identities.IntegrationTests</AssemblyName>
 		<RootNamespace>Architect.Identities.IntegrationTests</RootNamespace>
-		<IsPackable>false</IsPackable>
+		<ImplicitUsings>Enable</ImplicitUsings>
+		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Identities.IntegrationTests/Identities.IntegrationTests.csproj
+++ b/Identities.IntegrationTests/Identities.IntegrationTests.csproj
@@ -7,13 +7,6 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
-		<NoWarn>1573;1591;CA1822</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="3.1.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Identities.IntegrationTests/Identities.IntegrationTests.csproj
+++ b/Identities.IntegrationTests/Identities.IntegrationTests.csproj
@@ -1,23 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.IntegrationTests</AssemblyName>
-    <RootNamespace>Architect.Identities.IntegrationTests</RootNamespace>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyName>Architect.Identities.IntegrationTests</AssemblyName>
+		<RootNamespace>Architect.Identities.IntegrationTests</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
+		<NoWarn>1573;1591;CA1822</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.Tests/ApplicationInstanceIds/Implementations/AzureBlobApplicationInstanceIdRenterTests.cs
+++ b/Identities.Tests/ApplicationInstanceIds/Implementations/AzureBlobApplicationInstanceIdRenterTests.cs
@@ -47,7 +47,7 @@ namespace Architect.Identities.Tests.ApplicationInstanceIds.Implementations
 		[Fact]
 		public void RentId_WithNoPriorIds_ShouldAddId1()
 		{
-			System.Diagnostics.Debug.Assert(this.Repo.Blobs.Count == 0);
+			System.Diagnostics.Debug.Assert(this.Repo.Blobs.IsEmpty);
 
 			_ = this.Renter.RentId();
 
@@ -58,7 +58,7 @@ namespace Architect.Identities.Tests.ApplicationInstanceIds.Implementations
 		[Fact]
 		public void RentId_WithOnlyPriorId1_ShouldAddId2()
 		{
-			this.Repo.Blobs.TryAdd("1", new byte[0]);
+			this.Repo.Blobs.TryAdd("1", Array.Empty<byte>());
 
 			_ = this.Renter.RentId();
 
@@ -68,7 +68,7 @@ namespace Architect.Identities.Tests.ApplicationInstanceIds.Implementations
 		[Fact]
 		public void RentId_WithOnlyPriorId100_ShouldAddId1()
 		{
-			this.Repo.Blobs.TryAdd("100", new byte[0]);
+			this.Repo.Blobs.TryAdd("100", Array.Empty<byte>());
 
 			_ = this.Renter.RentId();
 
@@ -90,13 +90,13 @@ namespace Architect.Identities.Tests.ApplicationInstanceIds.Implementations
 		[Fact]
 		public void ReturnId_WithMultipleIdsPresent_ShouldOnlyTouchOwnId()
 		{
-			this.Repo.Blobs.TryAdd("1", new byte[0]);
+			this.Repo.Blobs.TryAdd("1", Array.Empty<byte>());
 
 			var id = this.Renter.RentId();
 
 			Assert.Contains("2", this.Repo.Blobs.Keys);
 
-			this.Repo.Blobs.TryAdd("3", new byte[0]);
+			this.Repo.Blobs.TryAdd("3", Array.Empty<byte>());
 
 			this.Renter.ReturnId(id);
 

--- a/Identities.Tests/ApplicationInstanceIds/Implementations/AzureBlobApplicationInstanceIdRenterTests.cs
+++ b/Identities.Tests/ApplicationInstanceIds/Implementations/AzureBlobApplicationInstanceIdRenterTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.Collections.Concurrent;
 using Architect.Identities.ApplicationInstanceIds;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Identities.Tests/DistributedIds/DistributedIdGeneratorTests.cs
+++ b/Identities.Tests/DistributedIds/DistributedIdGeneratorTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
+﻿using System.Buffers.Binary;
 using System.Globalization;
-using System.Linq;
 using Xunit;
 
 namespace Architect.Identities.Tests.DistributedIds

--- a/Identities.Tests/DistributedIds/IncrementalDistributedIdGeneratorTests.cs
+++ b/Identities.Tests/DistributedIds/IncrementalDistributedIdGeneratorTests.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Concurrent;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Architect.Identities.Tests.DistributedIds

--- a/Identities.Tests/DistributedIds/RandomSequence6Tests.cs
+++ b/Identities.Tests/DistributedIds/RandomSequence6Tests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Buffers.Binary;
 using Xunit;
 
 namespace Architect.Identities.Tests.DistributedIds

--- a/Identities.Tests/Encodings/Base62Tests.cs
+++ b/Identities.Tests/Encodings/Base62Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Architect.Identities.Encodings;
+﻿using Architect.Identities.Encodings;
 using Xunit;
 
 namespace Architect.Identities.Tests.Encodings

--- a/Identities.Tests/Encodings/HexadecimalTests.cs
+++ b/Identities.Tests/Encodings/HexadecimalTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Architect.Identities.Encodings;
+﻿using Architect.Identities.Encodings;
 using Xunit;
 
 namespace Architect.Identities.Tests.Encodings

--- a/Identities.Tests/Encodings/IdEncoderDecimalTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderDecimalTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Text;
 using Xunit;
 

--- a/Identities.Tests/Encodings/IdEncoderDecimalTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderDecimalTests.cs
@@ -60,8 +60,8 @@ namespace Architect.Identities.Tests.Encodings
 			{
 				IdEncoder.TryGetDecimal(bytes, out _),
 				IdEncoder.TryGetDecimal(chars, out _),
-				IdEncoder.GetDecimalOrDefault(bytes) != null,
-				IdEncoder.GetDecimalOrDefault(chars) != null,
+				IdEncoder.GetDecimalOrDefault(bytes) is not null,
+				IdEncoder.GetDecimalOrDefault(chars) is not null,
 			};
 		}
 

--- a/Identities.Tests/Encodings/IdEncoderGuidTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderGuidTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using System.Text;
 using Architect.Identities.Helpers;

--- a/Identities.Tests/Encodings/IdEncoderGuidTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderGuidTests.cs
@@ -95,8 +95,8 @@ namespace Architect.Identities.Tests.Encodings
 			{
 				IdEncoder.TryGetGuid(bytes, out _),
 				IdEncoder.TryGetGuid(chars, out _),
-				IdEncoder.GetGuidOrDefault(bytes) != null,
-				IdEncoder.GetGuidOrDefault(chars) != null,
+				IdEncoder.GetGuidOrDefault(bytes) is not null,
+				IdEncoder.GetGuidOrDefault(chars) is not null,
 			};
 		}
 

--- a/Identities.Tests/Encodings/IdEncoderLongTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderLongTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Architect.Identities.Tests.Encodings
 {

--- a/Identities.Tests/Encodings/IdEncoderUlongTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderUlongTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Xunit;
 
 namespace Architect.Identities.Tests.Encodings

--- a/Identities.Tests/Encodings/IdEncoderUlongTests.cs
+++ b/Identities.Tests/Encodings/IdEncoderUlongTests.cs
@@ -60,8 +60,8 @@ namespace Architect.Identities.Tests.Encodings
 			{
 				IdEncoder.TryGetUlong(bytes, out _),
 				IdEncoder.TryGetUlong(chars, out _),
-				IdEncoder.GetUlongOrDefault(bytes) != null,
-				IdEncoder.GetUlongOrDefault(chars) != null,
+				IdEncoder.GetUlongOrDefault(bytes) is not null,
+				IdEncoder.GetUlongOrDefault(chars) is not null,
 			};
 		}
 

--- a/Identities.Tests/Encodings/IdEncodingExtensionTests.cs
+++ b/Identities.Tests/Encodings/IdEncodingExtensionTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Architect.Identities.Tests.Encodings
 {

--- a/Identities.Tests/EntityFramework/SqliteDetectorTests.cs
+++ b/Identities.Tests/EntityFramework/SqliteDetectorTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Architect.Identities.EntityFramework;
+﻿using Architect.Identities.EntityFramework;
 using Xunit;
 
 namespace Architect.Identities.Tests.EntityFramework

--- a/Identities.Tests/EntityFramework/SqliteDetectorTests.cs
+++ b/Identities.Tests/EntityFramework/SqliteDetectorTests.cs
@@ -12,7 +12,7 @@ namespace Architect.Identities.Tests.EntityFramework
 			// Assert that no SQLite assemblies are loaded (except System.Data.SQLite, which seems to be quite standard)
 			var anySqliteAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly =>
 				assembly.FullName?.Contains("SQLite", StringComparison.OrdinalIgnoreCase) == true);
-			if (anySqliteAssembly != null) throw new Exception("SQLite was inadvertently loaded in this unit test library.");
+			if (anySqliteAssembly is not null) throw new Exception("SQLite was inadvertently loaded in this unit test library.");
 		}
 
 		/// <summary>

--- a/Identities.Tests/IdGenerators/CustomIdGeneratorTests.cs
+++ b/Identities.Tests/IdGenerators/CustomIdGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators
 {

--- a/Identities.Tests/IdGenerators/Fluids/FluidBitDistributionTests.cs
+++ b/Identities.Tests/IdGenerators/Fluids/FluidBitDistributionTests.cs
@@ -8,7 +8,7 @@ namespace Architect.Identities.Tests.IdGenerators.Fluids
 		[Fact]
 		public void Construct_With64TotalBits_ShouldSucceed()
 		{
-			new FluidBitDistribution(43, 11, 10);
+			_ = new FluidBitDistribution(43, 11, 10);
 		}
 		
 		[Fact]
@@ -48,7 +48,7 @@ namespace Architect.Identities.Tests.IdGenerators.Fluids
 		[Fact]
 		public void Construct_With16ApplicationInstanceIdBits_ShouldSucceed()
 		{
-			new FluidBitDistribution(43, 16, 5);
+			_ = new FluidBitDistribution(43, 16, 5);
 		}
 
 		[Fact]

--- a/Identities.Tests/IdGenerators/Fluids/FluidBitDistributionTests.cs
+++ b/Identities.Tests/IdGenerators/Fluids/FluidBitDistributionTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators.Fluids
 {

--- a/Identities.Tests/IdGenerators/Fluids/FluidIdGeneratorTests.cs
+++ b/Identities.Tests/IdGenerators/Fluids/FluidIdGeneratorTests.cs
@@ -423,7 +423,6 @@ namespace Architect.Identities.Tests.IdGenerators.Fluids
 			Assert.Equal(expectedValue, (ulong)fluid);
 		}
 
-
 		[Fact]
 		public void CreateFluid_WithClockThrowingOnSecondInvocationForOneFluid_ShouldNotChangeCounter()
 		{

--- a/Identities.Tests/IdGenerators/Fluids/FluidIdGeneratorTests.cs
+++ b/Identities.Tests/IdGenerators/Fluids/FluidIdGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators.Fluids

--- a/Identities.Tests/IdGenerators/Fluids/FluidTests.cs
+++ b/Identities.Tests/IdGenerators/Fluids/FluidTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators.Fluids

--- a/Identities.Tests/IdGenerators/IdGeneratorExtensionsTests.cs
+++ b/Identities.Tests/IdGenerators/IdGeneratorExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 

--- a/Identities.Tests/IdGenerators/IdGeneratorScopeTests.cs
+++ b/Identities.Tests/IdGenerators/IdGeneratorScopeTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Architect.Identities.Helpers;
+﻿using Architect.Identities.Helpers;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 

--- a/Identities.Tests/IdGenerators/IdGeneratorTests.cs
+++ b/Identities.Tests/IdGenerators/IdGeneratorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Architect.Identities.Helpers;
+﻿using Architect.Identities.Helpers;
 using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators

--- a/Identities.Tests/IdGenerators/IncrementalIdGeneratorTests.cs
+++ b/Identities.Tests/IdGenerators/IncrementalIdGeneratorTests.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Architect.Identities.Tests.IdGenerators

--- a/Identities.Tests/Identities.Tests.csproj
+++ b/Identities.Tests/Identities.Tests.csproj
@@ -4,7 +4,8 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyName>Architect.Identities.Tests</AssemblyName>
 		<RootNamespace>Architect.Identities.Tests</RootNamespace>
-		<IsPackable>false</IsPackable>
+		<ImplicitUsings>Enable</ImplicitUsings>
+		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Identities.Tests/Identities.Tests.csproj
+++ b/Identities.Tests/Identities.Tests.csproj
@@ -7,13 +7,6 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
-		<NoWarn>1573;1591;CA1822</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="3.1.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Identities.Tests/Identities.Tests.csproj
+++ b/Identities.Tests/Identities.Tests.csproj
@@ -1,24 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities.Tests</AssemblyName>
-    <RootNamespace>Architect.Identities.Tests</RootNamespace>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyName>Architect.Identities.Tests</AssemblyName>
+		<RootNamespace>Architect.Identities.Tests</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
+		<NoWarn>1573;1591;CA1822</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities.Azure\Identities.Azure.csproj" />
-    <ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Identities.Azure\Identities.Azure.csproj" />
+		<ProjectReference Include="..\Identities.EntityFramework\Identities.EntityFramework.csproj" />
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Identities.Tests/PublicIdentities/AesPublicIdentityConverterTests.cs
+++ b/Identities.Tests/PublicIdentities/AesPublicIdentityConverterTests.cs
@@ -342,7 +342,7 @@ namespace Architect.Identities.Tests.PublicIdentities
 
 			var decodedId = this.Converter.GetUlongOrDefault(guid);
 
-			Assert.Equal(decodingShouldSucceed, decodedId != null);
+			Assert.Equal(decodingShouldSucceed, decodedId is not null);
 			Assert.Equal(expectedId, decodedId);
 		}
 
@@ -357,7 +357,7 @@ namespace Architect.Identities.Tests.PublicIdentities
 
 			var decodedId = this.Converter.GetLongOrDefault(guid);
 
-			Assert.Equal(decodingShouldSucceed, decodedId != null);
+			Assert.Equal(decodingShouldSucceed, decodedId is not null);
 			Assert.Equal(expectedId, decodedId);
 		}
 
@@ -373,7 +373,7 @@ namespace Architect.Identities.Tests.PublicIdentities
 
 			var decodedId = this.Converter.GetDecimalOrDefault(guid);
 
-			Assert.Equal(decodingShouldSucceed, decodedId != null);
+			Assert.Equal(decodingShouldSucceed, decodedId is not null);
 			Assert.Equal(expectedId, decodedId);
 		}
 

--- a/Identities.Tests/PublicIdentities/AesPublicIdentityConverterTests.cs
+++ b/Identities.Tests/PublicIdentities/AesPublicIdentityConverterTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Xunit;
 

--- a/Identities.Tests/PublicIdentities/PublicIdentityExtensionsTests.cs
+++ b/Identities.Tests/PublicIdentities/PublicIdentityExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 

--- a/Identities.sln
+++ b/Identities.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Identities", "Identities\Identities.csproj", "{81DD7BFB-A472-458E-9184-678518FF65CA}"
 EndProject
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Identities.Tests", "Identit
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{40ADCE6A-4A53-4F2B-8152-140CA2E363C9}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		pipeline-publish-preview-identities-azure.yml = pipeline-publish-preview-identities-azure.yml
 		pipeline-publish-preview-identities-entityframework.yml = pipeline-publish-preview-identities-entityframework.yml
 		pipeline-publish-preview-identities.yml = pipeline-publish-preview-identities.yml

--- a/Identities/ApplicationInstanceIds/ApplicationInstanceIdSourceDbConnectionFactory.cs
+++ b/Identities/ApplicationInstanceIds/ApplicationInstanceIdSourceDbConnectionFactory.cs
@@ -31,7 +31,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 		public DbConnection CreateDbConnection()
 		{
 			var connection = this.GetConnection(this.ServiceProvider) ?? throw new Exception("The factory produced a null connection object.");
-			if (this.ConnectionString != null) connection.ConnectionString = this.ConnectionString;
+			if (this.ConnectionString is not null) connection.ConnectionString = this.ConnectionString;
 			return connection;
 		}
 

--- a/Identities/ApplicationInstanceIds/ApplicationInstanceIdSourceExtensions.cs
+++ b/Identities/ApplicationInstanceIds/ApplicationInstanceIdSourceExtensions.cs
@@ -106,7 +106,7 @@ namespace Architect.Identities
 			if (applicationInstanceIdSource is not DefaultApplicationInstanceIdSource defaultSource)
 				return serviceProvider;
 
-			if (defaultSource._applicationInstanceId != null) // Already resolved
+			if (defaultSource._applicationInstanceId is not null) // Already resolved
 				return serviceProvider;
 
 			var applicationLifetime = serviceProvider.GetRequiredService<IHostApplicationLifetime>();

--- a/Identities/ApplicationInstanceIds/DefaultApplicationInstanceIdSource.cs
+++ b/Identities/ApplicationInstanceIds/DefaultApplicationInstanceIdSource.cs
@@ -16,7 +16,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 
 		internal void SetApplicationInstanceId(ushort applicationInstanceId)
 		{
-			if (this._applicationInstanceId != null)
+			if (this._applicationInstanceId is not null)
 				throw new InvalidOperationException("An application instance ID was already configured.");
 
 			this._applicationInstanceId = applicationInstanceId;

--- a/Identities/ApplicationInstanceIds/Implementations/SqlApplicationInstanceIdRenter.cs
+++ b/Identities/ApplicationInstanceIds/Implementations/SqlApplicationInstanceIdRenter.cs
@@ -33,7 +33,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 			this.TransactionalExecutor = serviceProvider.GetRequiredService<IApplicationInstanceIdSourceTransactionalExecutor>();
 
 			var customTableName = serviceProvider.GetService<ApplicationInstanceIdCustomTableName>();
-			if (customTableName != null) this.TableName = customTableName.TableName;
+			if (customTableName is not null) this.TableName = customTableName.TableName;
 
 			this.DatabaseName = databaseName;
 
@@ -56,7 +56,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 
 		protected override ushort GetContextUniqueApplicationInstanceIdCore()
 		{
-			if (Transaction.Current != null)
+			if (Transaction.Current is not null)
 				throw new Exception($"Unexpected database transaction during {this.GetType().Name}.{nameof(this.GetContextUniqueApplicationInstanceId)}.");
 
 			this.ExecuteTransactionally(connection => this.CreateTableIfNotExists(connection, this.DatabaseName));

--- a/Identities/ApplicationInstanceIds/Implementations/SqlServerApplicationInstanceIdRenter.cs
+++ b/Identities/ApplicationInstanceIds/Implementations/SqlServerApplicationInstanceIdRenter.cs
@@ -20,7 +20,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 
 		private static void ThrowIfDatabaseNameExcludesSchema(string? databaseAndSchemaName)
 		{
-			if (databaseAndSchemaName != null && databaseAndSchemaName.Count(chr => chr == '.') != 1)
+			if (databaseAndSchemaName is not null && databaseAndSchemaName.Count(chr => chr == '.') != 1)
 			{
 				throw new NotSupportedException(
 					$"{nameof(SqlServerApplicationInstanceIdRenter)} only supports specifying the database name outside of the connection string if the schema name is included, i.e. 'database.schema'.");

--- a/Identities/ApplicationInstanceIds/SqlTransactionalExecutor.cs
+++ b/Identities/ApplicationInstanceIds/SqlTransactionalExecutor.cs
@@ -18,7 +18,7 @@ namespace Architect.Identities.ApplicationInstanceIds
 
 		public object? ExecuteTransactionally(Func<DbConnection, object?> action)
 		{
-			if (System.Transactions.Transaction.Current != null)
+			if (System.Transactions.Transaction.Current is not null)
 				throw new Exception($"An an unexpected database transaction was present while attempting to create a new transaction.");
 
 			var connection = this.ConnectionFactory.CreateDbConnection() ?? throw new Exception("The factory produced a null connection object.");

--- a/Identities/IdGenerators/Fluids/FluidIdGenerator.cs
+++ b/Identities/IdGenerators/Fluids/FluidIdGenerator.cs
@@ -63,11 +63,11 @@ namespace Architect.Identities
 				throw new ArgumentException($"The given {nameof(utcClock)} produced a non-UTC datetime.");
 			}
 
-			if (epoch != null && epoch.Value.Kind != DateTimeKind.Utc)
+			if (epoch is not null && epoch.Value.Kind != DateTimeKind.Utc)
 			{
 				throw new ArgumentException($"The {nameof(this.Epoch)} must be in UTC.");
 			}
-			if (epoch != null && epoch.Value.TimeOfDay != TimeSpan.Zero)
+			if (epoch is not null && epoch.Value.TimeOfDay != TimeSpan.Zero)
 			{
 				throw new ArgumentException($"The {nameof(this.Epoch)} must not include a time component.");
 			}

--- a/Identities/Identities.csproj
+++ b/Identities/Identities.csproj
@@ -13,6 +13,16 @@
 		<VersionPrefix>1.0.2</VersionPrefix>
 		<PackageReleaseNotes></PackageReleaseNotes>
 		<Description>
+Release notes:
+
+1.0.2:
+- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
+
+1.0.1:
+- Now using AmbientContexts 1.1.0, for a performance improvement.
+
+Description:
+
 Reliable unique ID generation and management for distributed applications.
 
 Auto-increment IDs reveal sensitive information. UUIDs (also known as GUIDs) are inefficient as primary keys in a database. Having two different IDs is cumbersome and counterintuitive. We can do better.
@@ -23,14 +33,6 @@ Auto-increment IDs reveal sensitive information. UUIDs (also known as GUIDs) are
 - To assign a unique ID to each distinct application or instance thereof, use an ApplicationInstanceIdSource.
 
 https://github.com/TheArchitectDev/Architect.Identities
-
-Release notes:
-
-1.0.2:
-- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
-
-1.0.1:
-- Now using AmbientContexts 1.1.0, for a performance improvement.
 		</Description>
 		<Copyright>The Architect</Copyright>
 		<Company>The Architect</Company>

--- a/Identities/Identities.csproj
+++ b/Identities/Identities.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Architect.Identities</AssemblyName>
-    <RootNamespace>Architect.Identities</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<AssemblyName>Architect.Identities</AssemblyName>
+		<RootNamespace>Architect.Identities</RootNamespace>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-    <!-- NoWarn: 1591=MissingXmlComments -->
-    <NoWarn>1573;1591</NoWarn>
-    <LangVersion>latest</LangVersion>
-    <Nullable>Enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<NoWarn>1573;1591</NoWarn>
+		<LangVersion>latest</LangVersion>
+		<Nullable>Enable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <Description>
+	<PropertyGroup>
+		<VersionPrefix>1.0.2</VersionPrefix>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<Description>
 Reliable unique ID generation and management for distributed applications.
 
 Auto-increment IDs reveal sensitive information. UUIDs (also known as GUIDs) are inefficient as primary keys in a database. Having two different IDs is cumbersome and counterintuitive. We can do better.
@@ -32,30 +32,33 @@ https://github.com/TheArchitectDev/Architect.Identities
 
 Release notes:
 
+1.0.2:
+- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
+
 1.0.1:
 - Now using AmbientContexts 1.1.0, for a performance improvement.
-    </Description>
-    <Copyright>The Architect</Copyright>
-    <Company>The Architect</Company>
-    <Authors>TheArchitectDev, Timovzl</Authors>
-    <RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageTags>ID, IDs, identity, identities, Fluid, distributed, locally, unique, locally-unique, generator, generation, IdGenerator, UUID, GUID, auto-increment, primary, key, entity, entities, PublicIdentities, IdGeneratorScope, flexible</PackageTags>
-  </PropertyGroup>
+		</Description>
+		<Copyright>The Architect</Copyright>
+		<Company>The Architect</Company>
+		<Authors>TheArchitectDev, Timovzl</Authors>
+		<RepositoryUrl>https://github.com/TheArchitectDev/Architect.Identities</RepositoryUrl>
+		<RepositoryType>Git</RepositoryType>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageTags>ID, IDs, identity, identities, Fluid, distributed, locally, unique, locally-unique, generator, generation, IdGenerator, UUID, GUID, auto-increment, primary, key, entity, entities, PublicIdentities, IdGeneratorScope, flexible</PackageTags>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Architect.AmbientContexts" Version="1.1.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Architect.AmbientContexts" Version="1.1.1-*" />
+		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Identities/Identities.csproj
+++ b/Identities/Identities.csproj
@@ -4,15 +4,9 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<AssemblyName>Architect.Identities</AssemblyName>
 		<RootNamespace>Architect.Identities</RootNamespace>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<NoWarn>1573;1591</NoWarn>
-		<LangVersion>latest</LangVersion>
 		<Nullable>Enable</Nullable>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>9</LangVersion>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Test/DistributedIdGenerator.cs
+++ b/Test/DistributedIdGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Buffers.Binary;
-using System.Threading;
+﻿using System.Buffers.Binary;
 using Architect.Identities;
 
 // ReSharper disable once CheckNamespace

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Test
 {

--- a/Test/RandomSequence6.cs
+++ b/Test/RandomSequence6.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers.Binary;
+﻿using System.Buffers.Binary;
 using System.Security.Cryptography;
 
 // ReSharper disable once CheckNamespace

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -4,6 +4,8 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>Enable</Nullable>
+		<ImplicitUsings>Enable</ImplicitUsings>
+		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -6,13 +6,6 @@
 		<Nullable>Enable</Nullable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-		<!-- NoWarn: 1591=MissingXmlComments -->
-		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
-		<NoWarn>1573;1591;CA1822</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\Identities\Identities.csproj" />
 	</ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,13 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>Enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>Enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Identities\Identities.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+		<!-- NoWarn: 1591=MissingXmlComments -->
+		<!-- NoWarn: CA1822=MarkMembersAsStatic -->
+		<NoWarn>1573;1591;CA1822</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Identities\Identities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/pipeline-publish-preview-identities-azure.yml
+++ b/pipeline-publish-preview-identities-azure.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-publish-preview-identities-entityframework.yml
+++ b/pipeline-publish-preview-identities-entityframework.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-publish-preview-identities.yml
+++ b/pipeline-publish-preview-identities.yml
@@ -3,7 +3,7 @@ trigger:
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-publish-stable-identities-azure.yml
+++ b/pipeline-publish-stable-identities-azure.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-publish-stable-identities-entityframework.yml
+++ b/pipeline-publish-stable-identities-entityframework.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-publish-stable-identities.yml
+++ b/pipeline-publish-stable-identities.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 

--- a/pipeline-verify.yml
+++ b/pipeline-verify.yml
@@ -3,7 +3,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 
 steps:
 


### PR DESCRIPTION
- Now using AmbientContexts 1.1.1, which fixes extremely rare bugs and improves performance.
- [Identities.EntityFramework] Fixed an incompatibility with EF Core 6.0.0+ (caused by a breaking change in EF itself).