### PR TITLE
2.0.0: DistributedId now stays incremental even under clock adjustments of up to 1 second. (Note that the UTC clock remains unaffected by DST.)

### DIFF
--- a/Identities/DistributedIds/RandomSequence6.cs
+++ b/Identities/DistributedIds/RandomSequence6.cs
@@ -28,7 +28,7 @@ namespace Architect.Identities
 	/// </summary>
 	internal readonly struct RandomSequence6
 	{
-		private const ulong MaxValue = UInt64.MaxValue >> 16;
+		internal const ulong MaxValue = UInt64.MaxValue >> 16;
 		/// <summary>
 		/// The number of bits added by the <see cref="TryAddRandomBits(RandomSequence6, out RandomSequence6)"/> operation.
 		/// </summary>

--- a/Identities/Identities.csproj
+++ b/Identities/Identities.csproj
@@ -34,6 +34,7 @@ Release notes:
 - BREAKING: Now using AmbientContexts 2.0.0.
 - Semi-breaking: DistributedIds are now always 28 digits, to avoid a change from 27 to 28 digits in the future. Newly generated IDs will be significantly greater than before. Avoid downgrading after upgrading.
 - DistributedIds can now burst-generate ~128,000 IDs at once before the ~128 IDs per millisecond throttling kicks in. This makes it much less likely for throttling to be encountered.
+- DistributedId now stays incremental even under clock adjustments of up to 1 second. (Note that the UTC clock remains unaffected by DST.)
 - Hexadecimal ID encodings are now supported.
 - IPublicIdentityConverter now comes with a TestPublicIdentityConverter implementation for unit tests.
 - Added UnsupportedOSPlatform("browser") to PublicIdentities, due to continuing lack of AES support.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ public void ShowInversionOfControl()
 
 ### Benefits
 
-- Is incremental (even intra-millisecond), making it _significantly_ more efficient as a primary key than a UUID.
+- Is incremental (even intra-millisecond), making it _drastically_ more efficient as a primary key than a UUID.
+- Remains incremental even if clock synchronization adjusts the clock backwards (for adjustments of up to 1 second).
 - Is shorter than a UUID, making it more efficient as a primary key.
 - Like a UUID, can be generated on-the-fly, with no registration or synchronization whatsoever.
 - Like a UUID, makes collisions extremely unlikely.
@@ -151,7 +152,7 @@ DistributedIds have strong collision resistance. The probability of generating t
 
 Most notably, collisions across different timestamps are impossible, since the millisecond values differ.
 
-Within a single application replica, collisions during a particular millisecond are avoided (while maintaining the incremental nature) by reusing the previous random value (48 bits) and incrementing it by a smaller random value (41 bits). This guarantees unique IDs within the application replica, as long as the system clock is not adjusted backwards. Whenever it is, the scenario is comparable to having an additional replica (addressed below) during the repeated time span.
+Within a single application replica, collisions during a particular millisecond are avoided (while maintaining the incremental nature) by reusing the previous random value (48 bits) and incrementing it by a smaller random value (41 bits). This _guarantees_ unique IDs within the application replica, provided that the system clock is not adjusted backwards by more than 1 second. For larger backwards adjustments, the scenario is comparable to having an additional replica (addressed below) during the repeated time span.
 
 The scenario where collisions can occur is when multiple application replicas are generating IDs at the same millisecond. It is detailed below and should be negligible.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ public void ShowInversionOfControl()
 ### Benefits
 
 - Is incremental (even intra-millisecond), making it _drastically_ more efficient as a primary key than a UUID.
-- Remains incremental even if clock synchronization adjusts the clock backwards (for adjustments of up to 1 second).
+- Remains incremental even if clock synchronization adjusts the clock (for adjustments of up to 1 second).
 - Is shorter than a UUID, making it more efficient as a primary key.
 - Like a UUID, can be generated on-the-fly, with no registration or synchronization whatsoever.
 - Like a UUID, makes collisions extremely unlikely.


### PR DESCRIPTION
DistributedId now stays incremental even under clock adjustments of up to 1 second. (Note that the UTC clock remains unaffected by DST.)